### PR TITLE
Don't use `MaybeUninit::uninit().assume_init()` as a placeholder value

### DIFF
--- a/nt-list/src/list/base.rs
+++ b/nt-list/src/list/base.rs
@@ -42,20 +42,17 @@ where
     /// This function substitutes [`InitializeListHead`] of the Windows NT API.
     ///
     /// [`InitializeListHead`]: https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-initializelisthead
-    #[allow(clippy::uninit_assumed_init)]
     pub fn new() -> impl New<Output = Self> {
-        unsafe {
-            new::of(Self {
-                flink: ptr::null_mut(),
-                blink: ptr::null_mut(),
-                pin: PhantomPinned,
-            })
-            .with(|this| {
-                let this = this.get_unchecked_mut();
-                this.flink = (this as *mut Self).cast();
-                this.blink = this.flink;
-            })
-        }
+        new::of(Self {
+            flink: ptr::null_mut(),
+            blink: ptr::null_mut(),
+            pin: PhantomPinned,
+        })
+        .with(|this| {
+            let this = unsafe { this.get_unchecked_mut() };
+            this.flink = (this as *mut Self).cast();
+            this.blink = this.flink;
+        })
     }
 
     /// Moves all elements from `other` to the end of the list.
@@ -449,7 +446,6 @@ where
     /// Allows the creation of an `NtListEntry`, but leaves all fields uninitialized.
     ///
     /// Its fields are only initialized when an entry is pushed to a list.
-    #[allow(clippy::uninit_assumed_init)]
     pub fn new() -> Self {
         Self {
             flink: ptr::null_mut(),

--- a/nt-list/src/list/base.rs
+++ b/nt-list/src/list/base.rs
@@ -3,8 +3,8 @@
 
 use core::iter::FusedIterator;
 use core::marker::PhantomPinned;
-use core::mem::MaybeUninit;
 use core::pin::Pin;
+use core::ptr;
 
 use moveit::{new, New};
 
@@ -46,8 +46,8 @@ where
     pub fn new() -> impl New<Output = Self> {
         unsafe {
             new::of(Self {
-                flink: MaybeUninit::uninit().assume_init(),
-                blink: MaybeUninit::uninit().assume_init(),
+                flink: ptr::null_mut(),
+                blink: ptr::null_mut(),
                 pin: PhantomPinned,
             })
             .with(|this| {
@@ -451,12 +451,10 @@ where
     /// Its fields are only initialized when an entry is pushed to a list.
     #[allow(clippy::uninit_assumed_init)]
     pub fn new() -> Self {
-        unsafe {
-            Self {
-                flink: MaybeUninit::uninit().assume_init(),
-                blink: MaybeUninit::uninit().assume_init(),
-                pin: PhantomPinned,
-            }
+        Self {
+            flink: ptr::null_mut(),
+            blink: ptr::null_mut(),
+            pin: PhantomPinned,
         }
     }
 

--- a/nt-list/src/list/boxing.rs
+++ b/nt-list/src/list/boxing.rs
@@ -42,20 +42,17 @@ where
     /// This function substitutes [`InitializeListHead`] of the Windows NT API.
     ///
     /// [`InitializeListHead`]: https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-initializelisthead
-    #[allow(clippy::uninit_assumed_init)]
     pub fn new() -> impl New<Output = Self> {
-        unsafe {
-            new::of(Self(NtListHead {
-                flink: ptr::null_mut(),
-                blink: ptr::null_mut(),
-                pin: PhantomPinned,
-            }))
-            .with(|this| {
-                let this = this.get_unchecked_mut();
-                this.0.flink = (this as *mut Self).cast();
-                this.0.blink = this.0.flink;
-            })
-        }
+        new::of(Self(NtListHead {
+            flink: ptr::null_mut(),
+            blink: ptr::null_mut(),
+            pin: PhantomPinned,
+        }))
+        .with(|this| {
+            let this = unsafe { this.get_unchecked_mut() };
+            this.0.flink = (this as *mut Self).cast();
+            this.0.blink = this.0.flink;
+        })
     }
 
     /// Moves all elements from `other` to the end of the list.

--- a/nt-list/src/list/boxing.rs
+++ b/nt-list/src/list/boxing.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use core::marker::PhantomPinned;
-use core::mem::MaybeUninit;
 use core::pin::Pin;
+use core::ptr;
 
 use alloc::boxed::Box;
 use moveit::{new, New};
@@ -46,8 +46,8 @@ where
     pub fn new() -> impl New<Output = Self> {
         unsafe {
             new::of(Self(NtListHead {
-                flink: MaybeUninit::uninit().assume_init(),
-                blink: MaybeUninit::uninit().assume_init(),
+                flink: ptr::null_mut(),
+                blink: ptr::null_mut(),
                 pin: PhantomPinned,
             }))
             .with(|this| {

--- a/nt-list/src/single_list/base.rs
+++ b/nt-list/src/single_list/base.rs
@@ -3,7 +3,6 @@
 
 use core::iter::FusedIterator;
 use core::marker::PhantomData;
-use core::mem::MaybeUninit;
 use core::ptr;
 
 use super::traits::NtSingleList;
@@ -258,10 +257,8 @@ where
     /// Its fields are only initialized when an entry is pushed to a list.
     #[allow(clippy::uninit_assumed_init)]
     pub fn new() -> Self {
-        unsafe {
-            Self {
-                next: MaybeUninit::uninit().assume_init(),
-            }
+        Self {
+            next: ptr::null_mut(),
         }
     }
 

--- a/nt-list/src/single_list/base.rs
+++ b/nt-list/src/single_list/base.rs
@@ -255,7 +255,6 @@ where
     /// Allows the creation of an `NtSingleListEntry`, but leaves all fields uninitialized.
     ///
     /// Its fields are only initialized when an entry is pushed to a list.
-    #[allow(clippy::uninit_assumed_init)]
     pub fn new() -> Self {
         Self {
             next: ptr::null_mut(),


### PR DESCRIPTION
Fixes https://github.com/ColinFinck/nt-list/issues/2

As a side note the compiler even shows a warning about that:
![2022-10-14_15-23](https://user-images.githubusercontent.com/38225716/195836849-8124a36b-9f39-486c-a069-590b71485b76.png)
