### PR TITLE
Remove all int2ptr and ptr2int casts

### DIFF
--- a/nt-list/src/list/base.rs
+++ b/nt-list/src/list/base.rs
@@ -119,7 +119,7 @@ where
 
     /// Returns the [`NtListEntry`] for the given element.
     pub(crate) fn entry(element: &mut E) -> *mut NtListEntry<E, L> {
-        let element_ptr: *mut E = element;
+        let element_ptr = element as *mut E;
 
         // This is the canonical implementation of `byte_add`
         let entry = unsafe { element_ptr.cast::<u8>().add(E::offset()).cast::<E>() };

--- a/nt-list/src/list/base.rs
+++ b/nt-list/src/list/base.rs
@@ -474,8 +474,8 @@ where
     fn element_ptr(&self) -> *const E {
         let ptr = self as *const Self;
 
-        // This is the canonical implementation of `byte_add`
-        let ptr = unsafe { ptr.cast::<u8>().add(E::offset()).cast::<Self>() };
+        // This is the canonical implementation of `byte_sub`
+        let ptr = unsafe { ptr.cast::<u8>().sub(E::offset()).cast::<Self>() };
 
         ptr.cast()
     }

--- a/nt-list/src/single_list/base.rs
+++ b/nt-list/src/single_list/base.rs
@@ -49,9 +49,12 @@ where
 
     /// Returns the [`NtSingleListEntry`] for the given element.
     pub(crate) fn entry(element: &mut E) -> *mut NtSingleListEntry<E, L> {
-        let element_address = element as *mut _ as usize;
-        let entry_address = element_address + E::offset();
-        entry_address as *mut NtSingleListEntry<E, L>
+        let element_ptr: *mut E = element;
+
+        // This is the canonical implementation of `byte_add`
+        let entry = unsafe { element_ptr.cast::<u8>().add(E::offset()).cast::<E>() };
+
+        entry.cast()
     }
 
     /// Provides a reference to the first element, or `None` if the list is empty.
@@ -266,15 +269,20 @@ where
     }
 
     pub(crate) fn containing_record(&self) -> &E {
-        unsafe { &*(self.element_address() as *const E) }
+        unsafe { &*self.element_ptr() }
     }
 
     pub(crate) fn containing_record_mut(&mut self) -> &mut E {
-        unsafe { &mut *(self.element_address() as *mut E) }
+        unsafe { &mut *(self.element_ptr() as *mut E) }
     }
 
-    fn element_address(&self) -> usize {
-        self as *const _ as usize - E::offset()
+    fn element_ptr(&self) -> *const E {
+        let ptr = self as *const Self;
+
+        // This is the canonical implementation of `byte_sub`
+        let ptr = unsafe { ptr.cast::<u8>().sub(E::offset()).cast::<Self>() };
+
+        ptr.cast()
     }
 }
 

--- a/nt-list/src/single_list/base.rs
+++ b/nt-list/src/single_list/base.rs
@@ -49,7 +49,7 @@ where
 
     /// Returns the [`NtSingleListEntry`] for the given element.
     pub(crate) fn entry(element: &mut E) -> *mut NtSingleListEntry<E, L> {
-        let element_ptr: *mut E = element;
+        let element_ptr = element as *mut E;
 
         // This is the canonical implementation of `byte_add`
         let entry = unsafe { element_ptr.cast::<u8>().add(E::offset()).cast::<E>() };


### PR DESCRIPTION
int2ptr casts obscure the code and make it quite hard to analyze with tools like [miri](https://github.com/rust-lang/miri).
It doesn't seem like you _really_ need them (an artifact of `C` past?), so this PR removes them (replacing with pointer offsets).