### PR TITLE
Fix Tree Borrows & Stacked Borrows Violations

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,3 +22,16 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+
+  miri:
+    name: "Miri"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Miri
+        run: |
+          rustup toolchain install nightly --component miri
+          rustup override set nightly
+          cargo miri setup
+      - name: Test with Miri
+        run: cargo miri test --no-fail-fast

--- a/nt-list/src/list/base.rs
+++ b/nt-list/src/list/base.rs
@@ -460,25 +460,17 @@ where
     }
 
     pub(crate) unsafe fn containing_record<'a>(ptr: *const Self) -> &'a E {
-        unsafe { &*Self::element_ptr(ptr) }
+        // This is the canonical implementation of `byte_sub`
+        let element_ptr = unsafe { ptr.cast::<u8>().sub(E::offset()).cast::<Self>() };
+
+        unsafe { &*element_ptr.cast() }
     }
 
     pub(crate) unsafe fn containing_record_mut<'a>(ptr: *mut Self) -> &'a mut E {
-        unsafe { &mut *Self::element_ptr_mut(ptr) }
-    }
-
-    fn element_ptr(ptr: *const Self) -> *const E {
         // This is the canonical implementation of `byte_sub`
-        let ptr = unsafe { ptr.cast::<u8>().sub(E::offset()).cast::<Self>() };
+        let element_ptr = unsafe { ptr.cast::<u8>().sub(E::offset()).cast::<Self>() };
 
-        ptr.cast()
-    }
-
-    fn element_ptr_mut(ptr: *mut Self) -> *mut E {
-        // This is the canonical implementation of `byte_sub`
-        let ptr = unsafe { ptr.cast::<u8>().sub(E::offset()).cast::<Self>() };
-
-        ptr.cast()
+        unsafe { &mut *element_ptr.cast() }
     }
 
     pub(crate) unsafe fn remove(&mut self) {

--- a/nt-list/src/list/base.rs
+++ b/nt-list/src/list/base.rs
@@ -108,7 +108,7 @@ where
 
     /// Returns a const pointer to the "end marker element" (which is the address of our own `NtListHead`, but interpreted as a `NtListEntry` element address).
     pub(crate) fn end_marker(self: Pin<&Self>) -> *const NtListEntry<E, L> {
-        (self.get_ref() as *const _ as *mut Self).cast()
+        (self.get_ref() as *const Self).cast()
     }
 
     /// Returns a mutable pointer to the "end marker element" (which is the address of our own `NtListHead`, but interpreted as a `NtListEntry` element address).

--- a/nt-list/src/list/boxing.rs
+++ b/nt-list/src/list/boxing.rs
@@ -8,7 +8,7 @@ use core::ptr;
 use alloc::boxed::Box;
 use moveit::{new, New};
 
-use super::base::{Iter, IterMut, NtListHead};
+use super::base::{Iter, IterMut, NtListEntry, NtListHead};
 use super::traits::NtList;
 use crate::traits::{NtBoxedListElement, NtListElement, NtTypedList};
 
@@ -105,7 +105,7 @@ where
         // Traverse the list in the old-fashioned way and deallocate each element.
         while current != end_marker {
             unsafe {
-                let element = (*current).containing_record_mut();
+                let element = NtListEntry::containing_record_mut(current);
                 current = (*current).flink;
                 drop(Box::from_raw(element));
             }

--- a/nt-list/src/list/boxing.rs
+++ b/nt-list/src/list/boxing.rs
@@ -372,6 +372,74 @@ mod tests {
     }
 
     #[test]
+    fn test_clear_and_append() {
+        // Append two lists of equal size.
+        moveit! {
+            let mut list1 = NtBoxingListHead::<MyElement, MyList>::new();
+            let mut list2 = NtBoxingListHead::<MyElement, MyList>::new();
+        }
+
+        for i in 0..10 {
+            list1.as_mut().push_back(MyElement::new(i));
+            list2.as_mut().push_back(MyElement::new(i));
+        }
+
+        list1.as_mut().append(list2.as_mut());
+
+        assert_eq!(list1.as_ref().len(), 20);
+        assert_eq!(list2.as_ref().len(), 0);
+
+        for (i, element) in (0..10).chain(0..10).zip(list1.as_ref().iter()) {
+            assert_eq!(i, element.value);
+        }
+
+        verify_all_links(list1.as_ref().inner());
+
+        // Add more elements to both lists
+        list1.as_mut().push_back(MyElement::new(21));
+        list1.as_mut().push_front(MyElement::new(22));
+
+        list2.as_mut().push_back(MyElement::new(21));
+        list2.as_mut().push_front(MyElement::new(22));
+
+        // Append the final list to a cleared list.
+        moveit! {
+            let mut list3 = NtBoxingListHead::<MyElement, MyList>::new();
+        }
+
+        list3.as_mut().clear();
+        list3.as_mut().append(list1.as_mut());
+
+        assert_eq!(list3.as_ref().len(), 22);
+        assert_eq!(list1.as_ref().len(), 0);
+
+        verify_all_links(list3.as_ref().inner());
+    }
+
+    #[test]
+    fn test_clear_and_push() {
+        moveit! {
+            let mut list = NtBoxingListHead::<MyElement, MyList>::new();
+        }
+
+        list.as_mut().clear();
+
+        for i in 0..=3 {
+            list.as_mut().push_back(MyElement::new(i));
+        }
+        for i in 4..=6 {
+            list.as_mut().push_front(MyElement::new(i));
+        }
+
+        assert_eq!(list.as_ref().back().unwrap().value, 3);
+        assert_eq!(list.as_mut().back_mut().unwrap().value, 3);
+        assert_eq!(list.as_ref().front().unwrap().value, 6);
+        assert_eq!(list.as_mut().front_mut().unwrap().value, 6);
+
+        verify_all_links(list.as_ref().inner());
+    }
+
+    #[test]
     fn test_back_and_front() {
         moveit! {
             let mut list = NtBoxingListHead::<MyElement, MyList>::new();

--- a/nt-list/src/list/boxing.rs
+++ b/nt-list/src/list/boxing.rs
@@ -84,8 +84,8 @@ where
     ///
     /// Unlike [`NtListHead::clear`], this operation computes in *O*(*n*) time, because it
     /// needs to traverse all elements to deallocate them.
-    pub fn clear(self: Pin<&mut Self>) {
-        let end_marker = self.as_ref().inner().end_marker();
+    pub fn clear(mut self: Pin<&mut Self>) {
+        let end_marker = self.as_mut().inner_mut().end_marker_mut();
 
         // Get the link to the first element before it's being reset.
         let mut current = self.0.flink;
@@ -271,7 +271,7 @@ where
     where
         T: IntoIterator<Item = Box<E>>,
     {
-        let end_marker = self.as_ref().inner().end_marker();
+        let end_marker = self.as_mut().inner_mut().end_marker_mut();
         let mut previous = self.as_ref().inner().blink;
 
         for element in iter.into_iter() {

--- a/nt-list/src/single_list/base.rs
+++ b/nt-list/src/single_list/base.rs
@@ -60,14 +60,14 @@ where
     ///
     /// This operation computes in *O*(*1*) time.
     pub unsafe fn front(&self) -> Option<&E> {
-        (!self.is_empty()).then(|| (*self.next).containing_record())
+        (!self.is_empty()).then(|| NtSingleListEntry::containing_record(self.next))
     }
 
     /// Provides a mutable reference to the first element, or `None` if the list is empty.
     ///
     /// This operation computes in *O*(*1*) time.
     pub unsafe fn front_mut(&mut self) -> Option<&mut E> {
-        (!self.is_empty()).then(|| (*self.next).containing_record_mut())
+        (!self.is_empty()).then(|| NtSingleListEntry::containing_record_mut(self.next))
     }
 
     /// Returns `true` if the list is empty.
@@ -109,9 +109,9 @@ where
     /// [`PopEntryList`]: https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-popentrylist
     pub unsafe fn pop_front(&mut self) -> Option<&mut E> {
         (!self.is_empty()).then(|| {
-            let entry = &mut *self.next;
-            self.next = entry.next;
-            entry.containing_record_mut()
+            let entry = self.next;
+            self.next = (*entry).next;
+            NtSingleListEntry::containing_record_mut(entry)
         })
     }
 
@@ -144,7 +144,7 @@ where
         let mut current = self.next;
 
         while !current.is_null() {
-            let element = (*current).containing_record_mut();
+            let element = NtSingleListEntry::containing_record_mut(current);
 
             if f(element) {
                 previous = current;
@@ -190,9 +190,9 @@ where
             None
         } else {
             unsafe {
-                let element = (*self.current).containing_record();
+                let element_ptr = self.current;
                 self.current = (*self.current).next;
-                Some(element)
+                Some(NtSingleListEntry::<E, L>::containing_record(element_ptr))
             }
         }
     }
@@ -228,9 +228,9 @@ where
             None
         } else {
             unsafe {
-                let element = (*self.current).containing_record_mut();
+                let element_ptr = self.current;
                 self.current = (*self.current).next;
-                Some(element)
+                Some(NtSingleListEntry::containing_record_mut(element_ptr))
             }
         }
     }
@@ -264,26 +264,22 @@ where
         }
     }
 
-    pub(crate) fn containing_record(&self) -> &E {
-        unsafe { &*self.element_ptr() }
+    pub(crate) unsafe fn containing_record<'a>(ptr: *const Self) -> &'a E {
+        unsafe { &*Self::element_ptr(ptr) }
     }
 
-    pub(crate) fn containing_record_mut(&mut self) -> &mut E {
-        unsafe { &mut *self.element_ptr_mut() }
+    pub(crate) unsafe fn containing_record_mut<'a>(ptr: *mut Self) -> &'a mut E {
+        unsafe { &mut *Self::element_ptr_mut(ptr) }
     }
 
-    fn element_ptr(&self) -> *const E {
-        let ptr = self as *const Self;
-
+    fn element_ptr(ptr: *const Self) -> *const E {
         // This is the canonical implementation of `byte_sub`
         let ptr = unsafe { ptr.cast::<u8>().sub(E::offset()).cast::<Self>() };
 
         ptr.cast()
     }
 
-    fn element_ptr_mut(&mut self) -> *mut E {
-        let ptr = self as *mut Self;
-
+    fn element_ptr_mut(ptr: *mut Self) -> *mut E {
         // This is the canonical implementation of `byte_sub`
         let ptr = unsafe { ptr.cast::<u8>().sub(E::offset()).cast::<Self>() };
 

--- a/nt-list/src/single_list/base.rs
+++ b/nt-list/src/single_list/base.rs
@@ -269,11 +269,20 @@ where
     }
 
     pub(crate) fn containing_record_mut(&mut self) -> &mut E {
-        unsafe { &mut *(self.element_ptr() as *mut E) }
+        unsafe { &mut *self.element_ptr_mut() }
     }
 
     fn element_ptr(&self) -> *const E {
         let ptr = self as *const Self;
+
+        // This is the canonical implementation of `byte_sub`
+        let ptr = unsafe { ptr.cast::<u8>().sub(E::offset()).cast::<Self>() };
+
+        ptr.cast()
+    }
+
+    fn element_ptr_mut(&mut self) -> *mut E {
+        let ptr = self as *mut Self;
 
         // This is the canonical implementation of `byte_sub`
         let ptr = unsafe { ptr.cast::<u8>().sub(E::offset()).cast::<Self>() };

--- a/nt-list/src/single_list/base.rs
+++ b/nt-list/src/single_list/base.rs
@@ -265,25 +265,17 @@ where
     }
 
     pub(crate) unsafe fn containing_record<'a>(ptr: *const Self) -> &'a E {
-        unsafe { &*Self::element_ptr(ptr) }
+        // This is the canonical implementation of `byte_sub`
+        let element_ptr = unsafe { ptr.cast::<u8>().sub(E::offset()).cast::<Self>() };
+
+        unsafe { &*element_ptr.cast() }
     }
 
     pub(crate) unsafe fn containing_record_mut<'a>(ptr: *mut Self) -> &'a mut E {
-        unsafe { &mut *Self::element_ptr_mut(ptr) }
-    }
-
-    fn element_ptr(ptr: *const Self) -> *const E {
         // This is the canonical implementation of `byte_sub`
-        let ptr = unsafe { ptr.cast::<u8>().sub(E::offset()).cast::<Self>() };
+        let element_ptr = unsafe { ptr.cast::<u8>().sub(E::offset()).cast::<Self>() };
 
-        ptr.cast()
-    }
-
-    fn element_ptr_mut(ptr: *mut Self) -> *mut E {
-        // This is the canonical implementation of `byte_sub`
-        let ptr = unsafe { ptr.cast::<u8>().sub(E::offset()).cast::<Self>() };
-
-        ptr.cast()
+        unsafe { &mut *element_ptr.cast() }
     }
 }
 


### PR DESCRIPTION
Fixes #6

This resolves all TB violations, and with [`6a64bfd`](https://github.com/ColinFinck/nt-list/commit/6a64bfd8fa75e04be0f5d50133f2690f39e3abbc) also resolves all SB violations. I separated out the commit fixing the SB violations since it's still sound under TB without it, and in the event that a TB or TB-like model becomes the default for miri, that commit can easily be reverted.

This also adds miri to the CI workflow to hopefully catch any future UB.